### PR TITLE
added test for eth_getBlockByHash and eth_blockNumber

### DIFF
--- a/tests/core/endpoints/test_eth_block_number.py
+++ b/tests/core/endpoints/test_eth_block_number.py
@@ -1,0 +1,4 @@
+
+def test_eth_blockNumber(rpc_client):
+    result = rpc_client('eth_blockNumber')
+    assert result == 0

--- a/tests/core/endpoints/test_eth_get_block_by_hash.py
+++ b/tests/core/endpoints/test_eth_get_block_by_hash.py
@@ -1,0 +1,7 @@
+
+def test_eth_getBlockByHash(rpc_client):
+    block_0 = rpc_client("eth_getBlockByNumber", [0, False])
+
+    block_0_by_hash = rpc_client("eth_getBlockByHash", [block_0['hash'], False])
+
+    assert block_0_by_hash == block_0

--- a/tests/core/endpoints/test_eth_get_block_by_number.py
+++ b/tests/core/endpoints/test_eth_get_block_by_number.py
@@ -1,3 +1,4 @@
+
 def test_eth_getBlock(rpc_client):
     block = rpc_client(
         'eth_getBlockByNumber',


### PR DESCRIPTION
## What was wrong?
there were no tests for `eth_getBlockByHash` and `eth_blockNumber`.
Issue #3

## How was it fixed?

added tests for `eth_getBlockByHash` and `eth_blockNumber`.
