### PR TITLE
added tests for eth_getTransactionByHash, eth_getTransactionReceipt and eth_getTransactionByHash

### DIFF
--- a/tests/core/endpoints/test_eth_get_transaction_count.py
+++ b/tests/core/endpoints/test_eth_get_transaction_count.py
@@ -1,0 +1,38 @@
+def test_eth_sendTransaction(rpc_client, accounts):
+    for _ in range(3):
+        rpc_client(
+            method="eth_sendTransaction",
+            params=[{
+                "from": accounts[0],
+                "to": accounts[1],
+                "value": 1,
+            }],
+        )
+
+    for _ in range(5):
+        rpc_client(
+            method="eth_sendTransaction",
+            params=[{
+                "from": accounts[1],
+                "to": accounts[0],
+                "value": 1,
+            }],
+        )
+
+    account_0_txn_count = rpc_client(
+        method="eth_getTransactionCount",
+        params=[accounts[0]],
+    )
+    assert account_0_txn_count == 3
+
+    account_1_txn_count = rpc_client(
+        method="eth_getTransactionCount",
+        params=[accounts[1]],
+    )
+    assert account_1_txn_count == 5
+
+    account_2_txn_count = rpc_client(
+        method="eth_getTransactionCount",
+        params=[accounts[2]],
+    )
+    assert account_2_txn_count == 0

--- a/tests/core/endpoints/test_eth_get_transaction_count.py
+++ b/tests/core/endpoints/test_eth_get_transaction_count.py
@@ -1,4 +1,4 @@
-def test_eth_sendTransaction(rpc_client, accounts):
+def test_eth_TransactionCount(rpc_client, accounts):
     for _ in range(3):
         rpc_client(
             method="eth_sendTransaction",

--- a/tests/core/endpoints/test_eth_get_transaction_receipt.py
+++ b/tests/core/endpoints/test_eth_get_transaction_receipt.py
@@ -1,0 +1,27 @@
+def test_eth_getTransactionReceipt_for_unknown_receipt(rpc_client):
+    result = rpc_client(
+        method="eth_getTransactionReceipt",
+        params=["0x0000000000000000000000000000000000000000000000000000000000000000"],
+    )
+
+    assert result is None
+
+
+def test_eth_getTransactionReceipt(rpc_client, accounts):
+    tx_hash = rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+    tx_receipt = rpc_client(
+        method="eth_getTransactionReceipt",
+        params=[tx_hash]
+    )
+
+    assert tx_receipt
+    assert tx_receipt['transactionHash'] == tx_hash

--- a/tests/core/endpoints/test_eth_transaction_by_hash.py
+++ b/tests/core/endpoints/test_eth_transaction_by_hash.py
@@ -1,0 +1,27 @@
+def test_eth_getTransactionByHash_for_unknown_hash(rpc_client):
+    result = rpc_client(
+        method="eth_getTransactionByHash",
+        params=["0x0000000000000000000000000000000000000000000000000000000000000000"],
+    )
+
+    assert result is None
+
+
+def test_eth_getTransactionByHash(rpc_client, accounts):
+    tx_hash = rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+    txn = rpc_client(
+        method="eth_getTransactionByHash",
+        params=[tx_hash]
+    )
+
+    assert txn
+    assert txn['hash'] == tx_hash


### PR DESCRIPTION
## What was wrong?
There were no tests  for `eth_getTransactionByHash`, `eth_getTransactionReceipt` and `eth_getTransactionByHash`.
Issue #3

## How was it fixed?
added tests for `eth_getTransactionByHash`, `eth_getTransactionReceipt` and `eth_getTransactionByHash`.
