### PR TITLE
Correctly remap transactions that are returned with a block

### DIFF
--- a/eth_tester_rpc/formatter.py
+++ b/eth_tester_rpc/formatter.py
@@ -94,7 +94,17 @@ BLOCK_KEY_MAPPINGS = {
 }
 
 
-block_key_remapper = apply_key_map(BLOCK_KEY_MAPPINGS)
+# This is needed when transactions are returned as a part of requested block in their full form (not just ids),
+# such as when calling web3.eth.getBlock(123, fullTransactions=True)
+BLOCK_NESTED_REMAPPERS = {
+    'transactions': apply_formatter_to_array(apply_formatter_if(is_dict, transaction_key_remapper)),
+}
+
+
+block_key_remapper = compose(
+    apply_formatters_to_dict(BLOCK_NESTED_REMAPPERS),
+    apply_key_map(BLOCK_KEY_MAPPINGS),
+)
 
 
 TRANSACTION_PARAMS_MAPPING = {


### PR DESCRIPTION
This happens when calling web3.eth.getBlock(123, fullTransactions=True)

Without this fix, some features like web3 gas price strategies were broken.

Unfortunately, I don't have the time to write a test for this at the moment. However, the internal test I write looked something like this:

```
def test_block_transaction_remapping(web3, account_1, account_2):
    tx_hash = web3.eth.sendTransaction({
        'from': account_1,
        'to': account_2,
        'value': 1_000_000,
    })
    receipt = wait_for_transaction_receipt(web3, tx_hash)
    block = web3.eth.getBlock(receipt.blockNumber, full_transactions=True)
    transactions = block['transactions']
    transaction = transactions[0]
    assert 'gasPrice' in transaction  # should also assert other keys
```

Maybe that can serve as a starting point.