### PR TITLE
fix eth_getBlockByNumber with full_transactions=True

### DIFF
--- a/eth_tester_rpc/formatter.py
+++ b/eth_tester_rpc/formatter.py
@@ -94,7 +94,8 @@ BLOCK_KEY_MAPPINGS = {
 }
 
 
-# This is needed when transactions are returned as a part of requested block in their full form (not just ids),
+# This is needed when transactions are returned as a part of
+# requested block in their full form (not just ids),
 # such as when calling web3.eth.getBlock(123, fullTransactions=True)
 BLOCK_NESTED_REMAPPERS = {
     'transactions': apply_formatter_to_array(apply_formatter_if(is_dict, transaction_key_remapper)),

--- a/eth_tester_rpc/formatter.py
+++ b/eth_tester_rpc/formatter.py
@@ -94,7 +94,17 @@ BLOCK_KEY_MAPPINGS = {
 }
 
 
-block_key_remapper = apply_key_map(BLOCK_KEY_MAPPINGS)
+# This is needed when transactions are returned as a part of requested block in their full form (not just ids),
+# such as when calling web3.eth.getBlock(123, fullTransactions=True)
+BLOCK_NESTED_REMAPPERS = {
+    'transactions': apply_formatter_to_array(apply_formatter_if(is_dict, transaction_key_remapper)),
+}
+
+
+block_key_remapper = compose(
+    apply_formatters_to_dict(BLOCK_NESTED_REMAPPERS),
+    apply_key_map(BLOCK_KEY_MAPPINGS),
+)
 
 
 TRANSACTION_PARAMS_MAPPING = {

--- a/tests/core/endpoints/test_eth_get_block_by_number.py
+++ b/tests/core/endpoints/test_eth_get_block_by_number.py
@@ -5,3 +5,25 @@ def test_eth_getBlock(rpc_client):
         params=['0x01']
     )
     assert isinstance(block, dict)
+
+
+def test_eth_getBlock_full_tx(rpc_client, accounts):
+    rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": hex(1234),
+            "data": "0x1234",
+            "gas": hex(100000),
+            "gasPrice": hex(4321),
+        }],
+    )
+    block_number = rpc_client('eth_blockNumber')
+    block = rpc_client(
+        'eth_getBlockByNumber',
+        params=[hex(block_number), True]
+    )
+    assert len(block['transactions']) == 1
+    assert 'gasPrice' in block['transactions'][0]
+    assert isinstance(block, dict)


### PR DESCRIPTION
## What was wrong?
`eth_getBlockByNumber` with `full_transactions=True`.
closes #26

## How was it fixed?
Formatters were fixed to fix format nested transactions. 


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.pixabay.com/photo/2014/06/21/08/43/rabbit-373691__480.jpg)
