### PR TITLE
Add more rpc methods

### DIFF
--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -66,6 +66,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getBlockByHash, 'eth_getBlockByHash')
     add_method_with_lock(rpc_methods.eth_getBlockByNumber, 'eth_getBlockByNumber')
     add_method_with_lock(rpc_methods.eth_getTransactionByBlockHashAndIndex, 'eth_getTransactionByBlockHashAndIndex')
+    add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByHash, 'eth_getBlockTransactionCountByHash')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -65,12 +65,30 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getTransactionReceipt, 'eth_getTransactionReceipt')
     add_method_with_lock(rpc_methods.eth_getBlockByHash, 'eth_getBlockByHash')
     add_method_with_lock(rpc_methods.eth_getBlockByNumber, 'eth_getBlockByNumber')
-    add_method_with_lock(rpc_methods.eth_getTransactionByBlockHashAndIndex, 'eth_getTransactionByBlockHashAndIndex')
-    add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByHash, 'eth_getBlockTransactionCountByHash')
-    add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByNumber, 'eth_getBlockTransactionCountByNumber')
-    add_method_with_lock(rpc_methods.eth_getUncleCountByBlockHash, 'eth_getUncleCountByBlockHash')
-    add_method_with_lock(rpc_methods.eth_getUncleCountByBlockNumber, 'eth_getUncleCountByBlockNumber')
-    add_method_with_lock(rpc_methods.eth_getTransactionByBlockNumberAndIndex, 'eth_getTransactionByBlockNumberAndIndex')
+    add_method_with_lock(
+        rpc_methods.eth_getTransactionByBlockHashAndIndex,
+        'eth_getTransactionByBlockHashAndIndex'
+    )
+    add_method_with_lock(
+        rpc_methods.eth_getBlockTransactionCountByHash,
+        'eth_getBlockTransactionCountByHash'
+    )
+    add_method_with_lock(
+        rpc_methods.eth_getBlockTransactionCountByNumber,
+        'eth_getBlockTransactionCountByNumber'
+    )
+    add_method_with_lock(
+        rpc_methods.eth_getUncleCountByBlockHash,
+        'eth_getUncleCountByBlockHash'
+    )
+    add_method_with_lock(
+        rpc_methods.eth_getUncleCountByBlockNumber,
+        'eth_getUncleCountByBlockNumber'
+    )
+    add_method_with_lock(
+        rpc_methods.eth_getTransactionByBlockNumberAndIndex,
+        'eth_getTransactionByBlockNumberAndIndex'
+    )
     add_method_with_lock(rpc_methods.eth_getLogs, 'eth_getLogs')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -65,6 +65,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getTransactionReceipt, 'eth_getTransactionReceipt')
     add_method_with_lock(rpc_methods.eth_getBlockByHash, 'eth_getBlockByHash')
     add_method_with_lock(rpc_methods.eth_getBlockByNumber, 'eth_getBlockByNumber')
+    add_method_with_lock(rpc_methods.eth_getTransactionByBlockHashAndIndex, 'eth_getTransactionByBlockHashAndIndex')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -71,6 +71,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getUncleCountByBlockHash, 'eth_getUncleCountByBlockHash')
     add_method_with_lock(rpc_methods.eth_getUncleCountByBlockNumber, 'eth_getUncleCountByBlockNumber')
     add_method_with_lock(rpc_methods.eth_getTransactionByBlockNumberAndIndex, 'eth_getTransactionByBlockNumberAndIndex')
+    add_method_with_lock(rpc_methods.eth_getLogs, 'eth_getLogs')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -67,6 +67,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getBlockByNumber, 'eth_getBlockByNumber')
     add_method_with_lock(rpc_methods.eth_getTransactionByBlockHashAndIndex, 'eth_getTransactionByBlockHashAndIndex')
     add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByHash, 'eth_getBlockTransactionCountByHash')
+    add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByNumber, 'eth_getBlockTransactionCountByNumber')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -70,6 +70,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByNumber, 'eth_getBlockTransactionCountByNumber')
     add_method_with_lock(rpc_methods.eth_getUncleCountByBlockHash, 'eth_getUncleCountByBlockHash')
     add_method_with_lock(rpc_methods.eth_getUncleCountByBlockNumber, 'eth_getUncleCountByBlockNumber')
+    add_method_with_lock(rpc_methods.eth_getTransactionByBlockNumberAndIndex, 'eth_getTransactionByBlockNumberAndIndex')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -69,6 +69,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByHash, 'eth_getBlockTransactionCountByHash')
     add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByNumber, 'eth_getBlockTransactionCountByNumber')
     add_method_with_lock(rpc_methods.eth_getUncleCountByBlockHash, 'eth_getUncleCountByBlockHash')
+    add_method_with_lock(rpc_methods.eth_getUncleCountByBlockNumber, 'eth_getUncleCountByBlockNumber')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/eth_tester_rpc/server.py
+++ b/eth_tester_rpc/server.py
@@ -68,6 +68,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_getTransactionByBlockHashAndIndex, 'eth_getTransactionByBlockHashAndIndex')
     add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByHash, 'eth_getBlockTransactionCountByHash')
     add_method_with_lock(rpc_methods.eth_getBlockTransactionCountByNumber, 'eth_getBlockTransactionCountByNumber')
+    add_method_with_lock(rpc_methods.eth_getUncleCountByBlockHash, 'eth_getUncleCountByBlockHash')
     add_method_with_lock(rpc_methods.eth_newBlockFilter, 'eth_newBlockFilter')
     add_method_with_lock(rpc_methods.eth_newPendingTransactionFilter,
                          'eth_newPendingTransactionFilter')

--- a/tests/core/endpoints/test_eth_getLogs.py
+++ b/tests/core/endpoints/test_eth_getLogs.py
@@ -1,0 +1,18 @@
+
+
+def test_eth_getLogs(
+    rpc_client,
+    client_call_emitter,
+    Events,
+    LogFunctions,
+    LogTopics
+):
+    client_call_emitter(LogFunctions.logNoArgs, [Events.LogNoArguments])
+    filter_params = {
+        "fromBlock": 0,
+        "toBlock": "latest",
+    }
+    result = rpc_client('eth_getLogs', params=[filter_params])
+    assert len(result) == 1
+    log_entry = result[0]
+    assert LogTopics.LogNoArguments in log_entry['topics']

--- a/tests/core/endpoints/test_eth_get_block_transaction_count_by_hash.py
+++ b/tests/core/endpoints/test_eth_get_block_transaction_count_by_hash.py
@@ -1,0 +1,34 @@
+
+def test_eth_getBlockTransactionCountByHash(rpc_client, accounts):
+    block_number = rpc_client('eth_blockNumber')
+    block = rpc_client(
+        'eth_getBlockByNumber',
+        params=[block_number]
+    )
+    count = rpc_client(
+        method="eth_getBlockTransactionCountByHash",
+        params=[block['hash']]
+    )
+    assert count == 0
+
+    rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+    block_number = rpc_client('eth_blockNumber')
+    block = rpc_client(
+        'eth_getBlockByNumber',
+        params=[block_number]
+    )
+    count = rpc_client(
+        method="eth_getBlockTransactionCountByHash",
+        params=[block['hash']]
+    )
+
+    assert count == 1

--- a/tests/core/endpoints/test_eth_get_block_transaction_count_by_number.py
+++ b/tests/core/endpoints/test_eth_get_block_transaction_count_by_number.py
@@ -1,0 +1,25 @@
+def test_eth_getBlockTransactionCountByNumber(rpc_client, accounts):
+    block_number = rpc_client('eth_blockNumber')
+    count = rpc_client(
+        method="eth_getBlockTransactionCountByNumber",
+        params=[block_number]
+    )
+    assert count == 0
+
+    rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+    block_number = rpc_client('eth_blockNumber')
+    count = rpc_client(
+        method="eth_getBlockTransactionCountByNumber",
+        params=[block_number]
+    )
+
+    assert count == 1

--- a/tests/core/endpoints/test_eth_get_transaction_by_block_number_and_index.py
+++ b/tests/core/endpoints/test_eth_get_transaction_by_block_number_and_index.py
@@ -1,0 +1,28 @@
+def test_eth_getTransactionByBlockNumberAndIndex_for_unknown_hash(rpc_client):
+    result = rpc_client(
+        method="eth_getTransactionByBlockNumberAndIndex",
+        params=[999999999999999999999999999999999999999, 0],
+    )
+
+    assert result is None
+
+
+def test_eth_getTransactionByBlockNumberAndIndex(rpc_client, accounts):
+    tx_hash = rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+    block_number = rpc_client('eth_blockNumber')
+    txn = rpc_client(
+        method="eth_getTransactionByBlockNumberAndIndex",
+        params=[block_number, 0]
+    )
+
+    assert txn
+    assert txn['hash'] == tx_hash

--- a/tests/core/endpoints/test_eth_get_transaction_by_blockhash_and_index.py
+++ b/tests/core/endpoints/test_eth_get_transaction_by_blockhash_and_index.py
@@ -1,0 +1,32 @@
+def test_eth_getTransactionByBlockHashAndIndex_for_unknown_hash(rpc_client):
+    result = rpc_client(
+        method="eth_getTransactionByBlockHashAndIndex",
+        params=["0x0000000000000000000000000000000000000000000000000000000000000000", 0],
+    )
+
+    assert result is None
+
+
+def test_eth_getTransactionByBlockHashAndIndex(rpc_client, accounts):
+    tx_hash = rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+    block_number = rpc_client('eth_blockNumber')
+    block = rpc_client(
+        'eth_getBlockByNumber',
+        params=[block_number]
+    )
+    txn = rpc_client(
+        method="eth_getTransactionByBlockHashAndIndex",
+        params=[block['hash'], 0]
+    )
+
+    assert txn
+    assert txn['hash'] == tx_hash

--- a/tests/core/endpoints/test_eth_get_uncle_count_by_block_hash.py
+++ b/tests/core/endpoints/test_eth_get_uncle_count_by_block_hash.py
@@ -1,0 +1,12 @@
+def test_eth_getUncleCountByBlockHash(rpc_client):
+    block_number = rpc_client('eth_blockNumber')
+    block = rpc_client(
+        'eth_getBlockByNumber',
+        params=[block_number]
+    )
+    count = rpc_client(
+        method="eth_getUncleCountByBlockHash",
+        params=[block['hash']]
+    )
+
+    assert count == 0

--- a/tests/core/endpoints/test_eth_get_uncle_count_by_block_number.py
+++ b/tests/core/endpoints/test_eth_get_uncle_count_by_block_number.py
@@ -1,0 +1,8 @@
+def test_eth_getUncleCountByBlockNumber(rpc_client):
+    block_number = rpc_client('eth_blockNumber')
+    count = rpc_client(
+        method="eth_getUncleCountByBlockNumber",
+        params=[block_number]
+    )
+
+    assert count == 0

--- a/tests/core/endpoints/test_get_transaction_by_hash.py
+++ b/tests/core/endpoints/test_get_transaction_by_hash.py
@@ -1,0 +1,28 @@
+def test_eth_getTransactionByHash_for_unknown_hash(rpc_client):
+    result = rpc_client(
+        method="eth_getTransactionByHash",
+        params=["0x0000000000000000000000000000000000000000000000000000000000000000"],
+    )
+
+    assert result is None
+
+
+def test_eth_getTransactionByHash(rpc_client, accounts):
+    tx_hash = rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": 1234,
+            "data": "0x1234",
+            "gas": 100000,
+        }],
+    )
+
+    txn = rpc_client(
+        method="eth_getTransactionByHash",
+        params=[tx_hash]
+    )
+
+    assert txn
+    assert txn['hash'] == tx_hash


### PR DESCRIPTION
## What was wrong?

some RPC methods were missing.

## How was it fixed?

Added new RPC methods:
- eth_getTransactionByBlockHashAndIndex
- eth_getBlockTransactionCountByHash
- eth_getBlockTransactionCountByNumber
- eth_getUncleCountByBlockHash
- eth_getUncleCountByBlockNumber
- eth_getTransactionByBlockNumberAndIndex


